### PR TITLE
Added conf_path metaparameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class ddclient(
   $server = "www.dnsdynamic.org",
   $protocol = "dyndns2",
   $use = "web, web=myip.dnsdynamic.com",
+  $conf_path = "/etc/ddclient.conf"
   ) {
 
   package { 'ddclient':
@@ -34,7 +35,8 @@ class ddclient(
     default: { }
   }
 
-  file { '/etc/ddclient.conf':
+  file { 'ddclient.conf':
+    path    => $conf_path,
     mode    => '0600',
     content => template('ddclient/ddclient.conf.erb'),
   } ~>

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,14 @@
+{
+  "author": "csanchez",
+  "dependencies": [],
+  "description": "A Puppet module to install and configure DDclient",
+  "license": "Apache License, Version 2.0",
+  "name": "csanchez-ddclient",
+  "operatingsystem_support": [],
+  "project_page": "http://github.com/carlossg/puppet-ddclient",
+  "requirements": [],
+  "source": "http://github.com/carlossg/puppet-ddclient",
+  "summary": "DDclient module for Puppet",
+  "tags": [],
+  "version": "1.0.1"
+}


### PR DESCRIPTION
It seems that with some releases of ddclient, the path is different. In the case of ddclient I have pulled from rpmforge, it need the path in /etc/ddclient/ddclient.conf. From what I see the best way is to just add a new parameter to allow the user to override the path
